### PR TITLE
fix display name for Ciandra's Essence

### DIFF
--- a/OracleOfDereth/Resources/augmentations.csv
+++ b/OracleOfDereth/Resources/augmentations.csv
@@ -50,7 +50,7 @@ Jibril's Essence,XP,226,Specialize Armor Tinkering,1bil,1,,https://acportalstorm
 Yoshi's Essence,XP,225,Specialize Item Tinkering,1bil,1,,https://acportalstorm.com/wiki/Yoshi%27s_Essence,Cragstone - Brienne Carlus 25.5N 48.4E
 Celdiseth's Essence,XP,227,Specialize Magic Item Tinkering,1bil,1,,https://acportalstorm.com/wiki/Celdiseth%27s_Essence,Cragstone - Burrell Sammrun 25.5N 48.4E
 Koga's Essence,XP,228,Specialize Weapon Tinkering,1bil,1,,https://acportalstorm.com/wiki/Koga%27s_Essence,Cragstone - Lenor Turk 25.5N 48.4E
-Ciandra's Fortune,XP,224,Specialize Salvaging,1bil,1,,https://acportalstorm.com/wiki/Ciandra%27s_Essence,Cragstone - Robert Crow 25.5N 48.4E
+Ciandra's Essence,XP,224,Specialize Salvaging,1bil,1,,https://acportalstorm.com/wiki/Ciandra%27s_Essence,Cragstone - Robert Crow 25.5N 48.4E
 Blank,XP,,,,,,,
 Skills,XP,,,,,,,
 Master of the Steel Circle,XP,300,+10 melee base skill with all melee weapons,2bil,1,,https://acportalstorm.com/wiki/Master_of_the_Steel_Circle,Silyun - Carlito Gallo 87.4N 70.5W 


### PR DESCRIPTION
Corrects the display name for Ciandra's Essence, which previously showed as a second Ciandra's Fortune.